### PR TITLE
fix(OwnershipEngine): not handling CRLF EOL

### DIFF
--- a/src/lib/ownership/OwnershipEngine.test.ts
+++ b/src/lib/ownership/OwnershipEngine.test.ts
@@ -158,6 +158,16 @@ describe('OwnershipEngine', () => {
       expect(() => OwnershipEngine.FromCodeownersFile('some/codeowners/file'))
         .toThrowError(expectedError);
     });
+
+    it('should parse CRLF files (#4)', () => {
+      // Arrange
+      const codeowners = 'some/path @global-owner1 @org/octocat docs@example.com\r\n';
+
+      readFileSyncMock.mockReturnValue(Buffer.from(codeowners));
+
+      // Assert
+      expect(() => OwnershipEngine.FromCodeownersFile('some/codeowners/file')).not.toThrow();
+    });
   });
 
   describe.each<any>(patterns)('$name: "$pattern"', ({ name, pattern, paths }) => {

--- a/src/lib/ownership/OwnershipEngine.ts
+++ b/src/lib/ownership/OwnershipEngine.ts
@@ -41,7 +41,7 @@ export class OwnershipEngine {
 
   public static FromCodeownersFile(filePath: string) {
     try {
-      const lines = fs.readFileSync(filePath).toString().split('\n');
+      const lines = fs.readFileSync(filePath).toString().replace(/\r/g, '').split('\n');
 
       const owned: FileOwnershipMatcher[] = [];
 


### PR DESCRIPTION
## Summary
- Resolves #4 
- Replaces `\r` with empty string before splitting by `\n`