### PR TITLE
Set exit code to `1` when unloved files or audit issues occur

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -34,7 +34,8 @@ commander.command('audit')
         options.dir = path.resolve(options.dir, options.root);
       }
 
-      await audit(options);
+      let result = await audit(options);
+      process.exit(result ? 0 : 1);
     } catch (error) {
       log.error('failed to run audit command', error);
       process.exit(1);
@@ -56,7 +57,8 @@ commander.command('validate')
         options.dir = path.resolve(options.dir, options.root);
       }
 
-      await validate(options);
+      let result = await validate(options);
+      process.exit(result ? 0 : 1);
     } catch (error) {
       log.error('failed to run validate command', error);
       process.exit(1);

--- a/src/commands/__snapshots__/audit.test.int.ts.snap
+++ b/src/commands/__snapshots__/audit.test.int.ts.snap
@@ -3,29 +3,29 @@
 exports[`audit csv should calculate stats when asked: stderr 1`] = `""`;
 
 exports[`audit csv should calculate stats when asked: stdout 1`] = `
-"owner,files,lines
+"owner,files,lines,percentage
 total,10,35,100
 loved,10,35,100
-unloved,0,0,100
-@doctocat,3,0
-@global-owner1,4,35
-@global-owner2,4,35
-@js-owner,2,0
-@octocat,1,0
+unloved,0,0,0
+@doctocat,3,0,0
+@global-owner1,4,35,100
+@global-owner2,4,35,100
+@js-owner,2,0,0
+@octocat,1,0,0
 "
 `;
 
 exports[`audit csv should do all commands in combination when asked: stderr 1`] = `""`;
 
 exports[`audit csv should do all commands in combination when asked: stdout 1`] = `
-"owner,files,lines
+"owner,files,lines,percentage
 total,5,2,100
 loved,5,2,100
-unloved,0,0,100
-@global-owner1,2,2
-@global-owner2,2,2
-@js-owner,2,0
-@octocat,1,0
+unloved,0,0,0
+@global-owner1,2,2,100
+@global-owner2,2,2,100
+@js-owner,2,0,0
+@octocat,1,0,0
 "
 `;
 
@@ -79,14 +79,14 @@ deep/nested-ignore/overridden-ignore.js,@js-owner
 exports[`audit jsonl should calculate stats when asked: stderr 1`] = `""`;
 
 exports[`audit jsonl should calculate stats when asked: stdout 1`] = `
-"{\\"total\\":{\\"files\\":10,\\"lines\\":35,\\"percentage\\":100},\\"unloved\\":{\\"files\\":0,\\"lines\\":0,\\"percentage\\":0},\\"loved\\":{\\"files\\":10,\\"lines\\":35,\\"percentage\\":100},\\"owners\\":[{\\"owner\\":\\"@global-owner1\\",\\"counters\\":{\\"files\\":4,\\"lines\\":35,\\"percentage\\":40}},{\\"owner\\":\\"@global-owner2\\",\\"counters\\":{\\"files\\":4,\\"lines\\":35,\\"percentage\\":40}},{\\"owner\\":\\"@doctocat\\",\\"counters\\":{\\"files\\":3,\\"lines\\":0,\\"percentage\\":30}},{\\"owner\\":\\"@octocat\\",\\"counters\\":{\\"files\\":1,\\"lines\\":0,\\"percentage\\":10}},{\\"owner\\":\\"@js-owner\\",\\"counters\\":{\\"files\\":2,\\"lines\\":0,\\"percentage\\":20}}]}
+"{\\"total\\":{\\"files\\":10,\\"lines\\":35,\\"percentage\\":100},\\"unloved\\":{\\"files\\":0,\\"lines\\":0,\\"percentage\\":0},\\"loved\\":{\\"files\\":10,\\"lines\\":35,\\"percentage\\":100},\\"owners\\":[{\\"owner\\":\\"@global-owner1\\",\\"counters\\":{\\"files\\":4,\\"lines\\":35,\\"percentage\\":100}},{\\"owner\\":\\"@global-owner2\\",\\"counters\\":{\\"files\\":4,\\"lines\\":35,\\"percentage\\":100}},{\\"owner\\":\\"@doctocat\\",\\"counters\\":{\\"files\\":3,\\"lines\\":0,\\"percentage\\":0}},{\\"owner\\":\\"@octocat\\",\\"counters\\":{\\"files\\":1,\\"lines\\":0,\\"percentage\\":0}},{\\"owner\\":\\"@js-owner\\",\\"counters\\":{\\"files\\":2,\\"lines\\":0,\\"percentage\\":0}}]}
 "
 `;
 
 exports[`audit jsonl should do all commands in combination when asked: stderr 1`] = `""`;
 
 exports[`audit jsonl should do all commands in combination when asked: stdout 1`] = `
-"{\\"total\\":{\\"files\\":5,\\"lines\\":2,\\"percentage\\":100},\\"unloved\\":{\\"files\\":0,\\"lines\\":0,\\"percentage\\":0},\\"loved\\":{\\"files\\":5,\\"lines\\":2,\\"percentage\\":100},\\"owners\\":[{\\"owner\\":\\"@octocat\\",\\"counters\\":{\\"files\\":1,\\"lines\\":0,\\"percentage\\":20}},{\\"owner\\":\\"@global-owner1\\",\\"counters\\":{\\"files\\":2,\\"lines\\":2,\\"percentage\\":40}},{\\"owner\\":\\"@global-owner2\\",\\"counters\\":{\\"files\\":2,\\"lines\\":2,\\"percentage\\":40}},{\\"owner\\":\\"@js-owner\\",\\"counters\\":{\\"files\\":2,\\"lines\\":0,\\"percentage\\":40}}]}
+"{\\"total\\":{\\"files\\":5,\\"lines\\":2,\\"percentage\\":100},\\"unloved\\":{\\"files\\":0,\\"lines\\":0,\\"percentage\\":0},\\"loved\\":{\\"files\\":5,\\"lines\\":2,\\"percentage\\":100},\\"owners\\":[{\\"owner\\":\\"@octocat\\",\\"counters\\":{\\"files\\":1,\\"lines\\":0,\\"percentage\\":0}},{\\"owner\\":\\"@global-owner1\\",\\"counters\\":{\\"files\\":2,\\"lines\\":2,\\"percentage\\":100}},{\\"owner\\":\\"@global-owner2\\",\\"counters\\":{\\"files\\":2,\\"lines\\":2,\\"percentage\\":100}},{\\"owner\\":\\"@js-owner\\",\\"counters\\":{\\"files\\":2,\\"lines\\":0,\\"percentage\\":0}}]}
 "
 `;
 
@@ -146,11 +146,11 @@ Total: 10 files (35 lines) 100%
 Loved: 10 files (35 lines) 100%
 Unloved: 0 files (0 lines 0%
 --- Owners ---
-@doctocat: 3 files (0 lines) 30%
-@global-owner1: 4 files (35 lines) 40%
-@global-owner2: 4 files (35 lines) 40%
-@js-owner: 2 files (0 lines) 20%
-@octocat: 1 files (0 lines) 10%
+@doctocat: 3 files (0 lines) 0%
+@global-owner1: 4 files (35 lines) 100%
+@global-owner2: 4 files (35 lines) 100%
+@js-owner: 2 files (0 lines) 0%
+@octocat: 1 files (0 lines) 0%
 "
 `;
 
@@ -163,10 +163,10 @@ Total: 5 files (2 lines) 100%
 Loved: 5 files (2 lines) 100%
 Unloved: 0 files (0 lines 0%
 --- Owners ---
-@global-owner1: 2 files (2 lines) 40%
-@global-owner2: 2 files (2 lines) 40%
-@js-owner: 2 files (0 lines) 40%
-@octocat: 1 files (0 lines) 20%
+@global-owner1: 2 files (2 lines) 100%
+@global-owner2: 2 files (2 lines) 100%
+@js-owner: 2 files (0 lines) 0%
+@octocat: 1 files (0 lines) 0%
 "
 `;
 

--- a/src/commands/__snapshots__/validate.test.int.ts.snap
+++ b/src/commands/__snapshots__/validate.test.int.ts.snap
@@ -1,8 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`validate when all owners are valid output the result of all validation checks: stderr 1`] = `
-"Found duplicate rules [ 'duplicate-rule.js @some-owner' ]
-Found rules which did not match any files [ 'file-does-not-exist.md @some-owner' ]
+"Found duplicate rules [ [32m'duplicate-rule.js @some-owner'[39m ]
+Found rules which did not match any files [ [32m'file-does-not-exist.md @some-owner'[39m ]
 "
 `;
 

--- a/src/commands/audit.ts
+++ b/src/commands/audit.ts
@@ -19,22 +19,26 @@ export const audit = async (options: AuditOptions) => {
   const filePaths = await getFilePaths(options.dir, strategy, options.root);
 
   const files = await getOwnership(options.codeowners, filePaths);
+  let success = true;
 
   if (options.stats) {
     await pMap(files, f => f.updateLineCount(), { concurrency: 100 });
 
     const stats = calcFileStats(files);
     statsWriter(stats, options, process.stdout);
-    return;
+    return success;
   }
 
   for (const file of files) {
     if (options.unloved) {
       if (file.owners.length < 1) {
+        success = false;
         file.write(options.output, process.stdout);
       }
     } else {
       file.write(options.output, process.stdout);
     }
   }
+
+  return success;
 };

--- a/src/commands/validate.ts
+++ b/src/commands/validate.ts
@@ -9,12 +9,17 @@ interface ValidateOptions {
 
 export const validate = async (options: ValidateOptions) => {
   const results = await assertValidRules(options); // will throw on errors such as badly formatted rules
+  let success = true;
 
-  if(results.duplicated.size > 0){
+  if (results.duplicated.size > 0) {
+    success = false;
     log.warn('Found duplicate rules', Array.from(results.duplicated.values()));
   }
 
-  if(results.unmatched.size > 0){
+  if (results.unmatched.size > 0) {
+    success = false;
     log.warn('Found rules which did not match any files', Array.from(results.unmatched.values()));
   }
+
+  return success;
 };


### PR DESCRIPTION
Set exit code to `1` if  unloved files were found or non-existent files are in CODEOWNERS file. 

Closes #9 