### PR TITLE
Handle paths with escaped white spaces

### DIFF
--- a/src/lib/ownership/OwnershipEngine.ts
+++ b/src/lib/ownership/OwnershipEngine.ts
@@ -63,7 +63,8 @@ export class OwnershipEngine {
 
 const createMatcherCodeownersRule = (rule: string): FileOwnershipMatcher => {
   // Split apart on spaces
-  const parts = rule.split(/\s+/);
+  const parts = rule.split(/\s+(?<!\\ )/);
+
 
   // The first part is expected to be the path
   const path = parts[0];


### PR DESCRIPTION
The current regex to split the paths in the CODEOWNERS fails for directories that contain white spaces in their names.